### PR TITLE
server harvesting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 /test/version_tmp/
 /tmp/
 /log/
+/output/
 
 # Used by dotenv library to load environment variables.
 # .env

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gem 'capistrano', '~> 3.11', require: false
 gem 'dlss-capistrano'
 gem 'capistrano-bundler'
 gem 'capistrano-rvm'
+gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,7 @@ DEPENDENCIES
   capistrano-bundler
   capistrano-rvm
   dlss-capistrano
+  rake
 
 BUNDLED WITH
    2.0.1

--- a/README.md
+++ b/README.md
@@ -8,13 +8,92 @@ need to be committed to Github and merged to master branch before deploying.
 
 `cap prod deploy`
 
+# Ensure necessary python libraries are installed
+
+The scripts require certain libraries to be installed on your laptop or server.
+You need `pip` (python package installed) to install these python libraries
+(pip is already setup on the server, along with python).
+
+```
+pip install lxml --user
+```
+
 # Running Scipts on Remove Server
 
 ```
 ssh harvester@dlme-harvest # to get to the machine
 cd current # to go the currently deployed code
+```
 
-# run your scripts, updated to place data in the /opt/app/harvester/output directory
+You can then run your scripts, which will place the data in an "output" subfolder.
+
+Note that you will probably want to run long running scripts in `screen` mode, so that
+you can log out of the server and have them continue to run.
+Full screen keyboard shortcuts: http://aperiodic.net/screen/quick_reference,
+but basically:
+
+```
+# will show any currently running background processes (could be none):
+screen -ls
+
+# start a new screen called "bnf", helpful to give a useful name for later (note capital -S)
+screen -S bnf
+```
+
+You will have a new process terminal window into which you can start a long running python
+script....once running, leave the process running and exit the screen by
+pressing `ctrl-a`, followed by `d`
+
+This will now show your long running process:
+
+```
+screen -ls
+```
+
+Log off the server if you want
+
+```
+exit
+```
+
+Go back to the server later and find your long running process:
+
+```
+ssh harvester@dlme-harvest.stanford.edu
+screen -ls
+```
+
+"Re-attach" to the process by name (substitute the name you used above when creating it):
+
+```
+screen -r bnf
+```
+
+If it is still running, exit with `ctrl-a`, `d` (like above) to keep the process going.
+Or else you can kill the screen process if everything is done with: `exit`.  You will then be back at the main level
+of the server, you can exit the server with `exit`.
+
+
+# Committing data directly to dlme-metadata repo
+
+The dlme-metadata repo is cloned on the server, and you can move data from the output folder and
+then commit directly.
+
+For example, this will move the everything that is currently in the "output" folder
+on the server into the dlme-metadata folder, where it can be ready to commit.
+You should confirm first that the data harvested in the output folder is correct
+before committing, and be sure to commit to a new branch in the dlme-metadata repo
+(as the example below shows):
+
+```
+ssh harvester@dlme-harvest.stanford.edu
+cd dlme-metadata
+mv ../current/output/ ./
+
+git checkout -b 'new-data-branch'
+git status
+git add .
+git commit -m 'new data'
 ```
 
 # Getting data off the machine

--- a/README.md
+++ b/README.md
@@ -12,13 +12,20 @@ need to be committed to Github and merged to master branch before deploying.
 
 The scripts require certain libraries to be installed on your laptop or server.
 You need `pip` (python package installed) to install these python libraries
-(pip is already setup on the server, along with python).
+(pip is already setup on the server, along with python).  You should not need to
+do this on the server (only first time setup)
 
 ```
 pip install lxml --user
+pip install sickle --user
 ```
 
 # Running Scipts on Remove Server
+
+Ensure you have a kerberos ticket:
+```
+kinit
+```
 
 ```
 ssh harvester@dlme-harvest # to get to the machine


### PR DESCRIPTION
fixes #7 

Note -- the info in the readme talks about an output folder location that requires changes to harvesting scripts in #10 

- add info on how to run scripts on server to readme
- add rake to gemfile (there appears to be rake tasks for princeton data?)
- add an output subfolder that can be used to store harvested data in
- add output subfolder to .gitignore to be sure no data gets committed to this repo