### PR TITLE
tweaks to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,26 +3,31 @@ DLME Scripts for harvesting data from providers
 
 # Harvest Scripts
 
+Both python 2 and python 3 are installed on the server.  Use `python` to run python 2 scripts and use
+`python3` to run python 3 scripts.  Note that any packages installed via `pip` will be installed under python 3 only.
+
 ## oai-harvest.py
 
 OAI-PMH collections can be harvested with `oai-harvest.py` by calling the script followed by the base url of the sources you wish to harvest, the metadata prefix, and the name of the institution.
 ```
-python oai-harvest.py http://cdm21044.contentdm.oclc.org/oai/oai.php -m oai_dc
+python3 oai-harvest.py http://cdm21044.contentdm.oclc.org/oai/oai.php -m oai_dc
 ```
 Files will be written to `output/data`,
 
 ### Optional flags
-* `-s` If `-s ` is called, the script will grab available sets first and files will be written to `output/set_name/data`. 
+* `-s` If `-s ` is called, the script will grab available sets first and files will be written to `output/set_name/data`.
 * `-i` If the `-i institution_name` is called, the script will look in the `do_not_harvest` dictionary in `helper.py` for the name of the institution and pass along sets to ignore if any are found.
 
-# Harvest Server 
+# Harvest Server
 
 ## Deployment
 
 To deploy the latest harvest scripts to the VM from your machine.  Note, all changes
-need to be committed to Github and merged to master branch before deploying.
+need to be committed to Github before deploying.  The default branch to deploy is
+master, but you can specify a specific branch name to deploy when issuing the cap command (or just press
+return when asked to accept the master branch.)
 
-`cap prod deploy`
+`bundle exec cap prod deploy`
 
 ## Ensure necessary python libraries are installed
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -4,8 +4,8 @@ lock '~> 3.11.0'
 set :application, 'dlme-harvest'
 set :repo_url, 'https://github.com/sul-dlss/dlme-harvest'
 
-# Default branch is :master
-#ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp
+# Default branch is :master, but can change
+ask :branch, 'master' # `git rev-parse --abbrev-ref HEAD`.chomp
 
 set :stages, %W(production)
 


### PR DESCRIPTION
1. tweaks to readme about python 2 vs 3 and deploying
2. Allow branches other than master to be deployed (for debugging purposes)